### PR TITLE
Add GoldTrendStrategy cBot for XAUUSD

### DIFF
--- a/Robots/XAUUSD Trend Strategy/XAUUSD Trend Strategy.sln
+++ b/Robots/XAUUSD Trend Strategy/XAUUSD Trend Strategy.sln
@@ -1,0 +1,20 @@
+
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gold Trend Strategy", "XAUUSD Trend Strategy\GoldTrendStrategy.csproj", "{9AE93258-B8C0-4BB7-9848-7E4F7C43B555}"
+EndProject
+Global
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|Any CPU = Debug|Any CPU
+                Release|Any CPU = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {9AE93258-B8C0-4BB7-9848-7E4F7C43B555}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {9AE93258-B8C0-4BB7-9848-7E4F7C43B555}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {9AE93258-B8C0-4BB7-9848-7E4F7C43B555}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {9AE93258-B8C0-4BB7-9848-7E4F7C43B555}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+        EndGlobalSection
+EndGlobal

--- a/Robots/XAUUSD Trend Strategy/XAUUSD Trend Strategy/GoldTrendStrategy.cs
+++ b/Robots/XAUUSD Trend Strategy/XAUUSD Trend Strategy/GoldTrendStrategy.cs
@@ -1,0 +1,98 @@
+// -------------------------------------------------------------------------------------------------
+//
+//    This code is a cTrader Algo API example.
+//
+//    This cBot is intended to be used as a sample and does not guarantee any particular outcome or
+//    profit of any kind. Use it at your own risk.
+//
+// -------------------------------------------------------------------------------------------------
+
+using cAlgo.API;
+using cAlgo.API.Indicators;
+
+namespace cAlgo.Robots
+{
+    [Robot(TimeZone = TimeZones.UTC, AccessRights = AccessRights.None, AddIndicators = true)]
+    public class GoldTrendStrategy : Robot
+    {
+        private double _volumeInUnits;
+        private SimpleMovingAverage _fastMa;
+        private SimpleMovingAverage _slowMa;
+        private RelativeStrengthIndex _rsi;
+
+        [Parameter("Fast MA Source", Group = "Fast MA")]
+        public DataSeries FastMaSource { get; set; }
+
+        [Parameter("Fast MA Period", DefaultValue = 50, Group = "Fast MA", MinValue = 1)]
+        public int FastMaPeriod { get; set; }
+
+        [Parameter("Slow MA Source", Group = "Slow MA")]
+        public DataSeries SlowMaSource { get; set; }
+
+        [Parameter("Slow MA Period", DefaultValue = 200, Group = "Slow MA", MinValue = 1)]
+        public int SlowMaPeriod { get; set; }
+
+        [Parameter("RSI Period", DefaultValue = 14, Group = "RSI", MinValue = 1)]
+        public int RsiPeriod { get; set; }
+
+        [Parameter("RSI Oversold", DefaultValue = 30, Group = "RSI", MinValue = 1, MaxValue = 50)]
+        public int Oversold { get; set; }
+
+        [Parameter("RSI Overbought", DefaultValue = 70, Group = "RSI", MinValue = 50, MaxValue = 100)]
+        public int Overbought { get; set; }
+
+        [Parameter("Volume (Lots)", DefaultValue = 0.01, Group = "Trade")]
+        public double VolumeInLots { get; set; }
+
+        [Parameter("Stop Loss (Pips)", DefaultValue = 100, Group = "Trade", MinValue = 1)]
+        public double StopLossInPips { get; set; }
+
+        [Parameter("Take Profit (Pips)", DefaultValue = 200, Group = "Trade", MinValue = 1)]
+        public double TakeProfitInPips { get; set; }
+
+        [Parameter("Label", DefaultValue = "GoldTrendStrategy", Group = "Trade")]
+        public string Label { get; set; }
+
+        protected override void OnStart()
+        {
+            if (SymbolName != "XAUUSD")
+                Print("Warning: This cBot is designed for XAUUSD. Current symbol is {0}.", SymbolName);
+
+            _volumeInUnits = Symbol.QuantityToVolumeInUnits(VolumeInLots);
+            _fastMa = Indicators.SimpleMovingAverage(FastMaSource, FastMaPeriod);
+            _slowMa = Indicators.SimpleMovingAverage(SlowMaSource, SlowMaPeriod);
+            _rsi = Indicators.RelativeStrengthIndex(MarketSeries.Close, RsiPeriod);
+
+            _fastMa.Result.Line.Color = Color.Gold;
+            _slowMa.Result.Line.Color = Color.DarkOrange;
+        }
+
+        protected override void OnBarClosed()
+        {
+            var inUptrend = _fastMa.Result.LastValue > _slowMa.Result.LastValue;
+            var inDowntrend = _fastMa.Result.LastValue < _slowMa.Result.LastValue;
+
+            if (inUptrend && _rsi.Result.LastValue < Oversold)
+            {
+                ClosePositions(TradeType.Sell);
+                ExecuteMarketOrder(TradeType.Buy, SymbolName, _volumeInUnits, Label, StopLossInPips, TakeProfitInPips);
+            }
+            else if (inDowntrend && _rsi.Result.LastValue > Overbought)
+            {
+                ClosePositions(TradeType.Buy);
+                ExecuteMarketOrder(TradeType.Sell, SymbolName, _volumeInUnits, Label, StopLossInPips, TakeProfitInPips);
+            }
+        }
+
+        private void ClosePositions(TradeType tradeType)
+        {
+            foreach (var position in Positions.FindAll(Label))
+            {
+                if (position.TradeType != tradeType)
+                    continue;
+
+                ClosePosition(position);
+            }
+        }
+    }
+}

--- a/Robots/XAUUSD Trend Strategy/XAUUSD Trend Strategy/GoldTrendStrategy.csproj
+++ b/Robots/XAUUSD Trend Strategy/XAUUSD Trend Strategy/GoldTrendStrategy.csproj
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <EnableDefaultItems>False</EnableDefaultItems>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+  </PropertyGroup>
+  <PropertyGroup>
+    <LangVersion>7.2</LangVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>cAlgo</RootNamespace>
+    <AssemblyName>Gold Trend Strategy</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="cTrader.Automate" Version="*-*" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="GoldTrendStrategy.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+</Project>

--- a/Robots/XAUUSD Trend Strategy/XAUUSD Trend Strategy/Properties/AssemblyInfo.cs
+++ b/Robots/XAUUSD Trend Strategy/XAUUSD Trend Strategy/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Gold Trend Strategy")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyProduct("Gold Trend Strategy")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("9f04b8d8-0ddb-4e77-bb31-abbf3a30c91b")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+#if DEBUG
+    [assembly: Debuggable(DebuggableAttribute.DebuggingModes.Default | DebuggableAttribute.DebuggingModes.DisableOptimizations)]
+#endif


### PR DESCRIPTION
## Summary
- implement `GoldTrendStrategy` robot for XAUUSD trend trading

## Testing
- `dotnet build Robots/XAUUSD\ Trend\ Strategy/XAUUSD\ Trend\ Strategy/GoldTrendStrategy.csproj -v minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3fd0471483238f1431efdcdbbb57